### PR TITLE
Update statsd.conf with updated metrics

### DIFF
--- a/statsd/statsd.conf
+++ b/statsd/statsd.conf
@@ -15,6 +15,13 @@ mappings:
     labels:
       airflow_id: "$1"
       job_name: "$2"
+  - match: "(.+)\\.(.+)_heartbeat_failure$"
+    match_metric_type: counter
+    name: "af_agg_heartbeat_failures"
+    match_type: regex
+    labels:
+      airflow_id: "$1"
+      operator_name: "$2"
   - match: "(.+)\\.operator_failures_(.+)$"
     match_metric_type: counter
     name: "af_agg_operator_failures"
@@ -39,6 +46,11 @@ mappings:
     name: "af_agg_ti_successes"
     labels:
       airflow_id: "$1"
+  - match: "*.previously_succeeded"
+    match_metric_type: counter
+    name: "af_agg_ti_previously_succeeded"
+    labels:
+      airflow_id: "$1"
   - match: "*.zombies_killed"
     match_metric_type: counter
     name: "af_agg_zombies_killed"
@@ -54,19 +66,19 @@ mappings:
     name: "af_agg_dag_processing_processes"
     labels:
       airflow_id: "$1"
+  - match: "*.dag_processing.manager_stalls"
+    match_metric_type: counter
+    name: "af_agg_dag_manager_stalls"
+    labels:
+      airflow_id: "$1"
+  - match: "*.dag_file_refresh_error"
+    match_metric_type: counter
+    name: "af_agg_dag_file_refresh_error"
+    labels:
+      airflow_id: "$1"
   - match: "*.scheduler.tasks.killed_externally"
     match_metric_type: counter
     name: "af_agg_scheduler_tasks_killed_externally"
-    labels:
-      airflow_id: "$1"
-  - match: "*.scheduler.tasks.running"
-    match_metric_type: counter
-    name: "af_agg_scheduler_tasks_running"
-    labels:
-      airflow_id: "$1"
-  - match: "*.scheduler.tasks.starving"
-    match_metric_type: counter
-    name: "af_agg_scheduler_tasks_starving"
     labels:
       airflow_id: "$1"
   - match: "*.scheduler.orphaned_tasks.cleared"
@@ -87,6 +99,11 @@ mappings:
   - match: "*.sla_email_notification_failure"
     match_metric_type: counter
     name: "af_agg_sla_email_notification_failure"
+    labels:
+      airflow_id: "$1"
+  - match: "*.sla_callback_notification_failure"
+    match_metric_type: counter
+    name: "af_agg_sla_callback_notification_failure"
     labels:
       airflow_id: "$1"
   - match: "*.ti.start.*.*"
@@ -114,6 +131,40 @@ mappings:
     name: "af_agg_celery_task_timeout_error"
     labels:
       airflow_id: "$1"
+  - match: "*.task_removed_from_dag.*"
+    match_metric_type: counter
+    name: "af_agg_task_removed_from_dag"
+    labels:
+      airflow_id: "$1"
+      dag_id: "$2"
+  - match: "*.task_restored_to_dag.*"
+    match_metric_type: counter
+    name: "af_agg_task_restored_from_dag"
+    labels:
+      airflow_id: "$1"
+      dag_id: "$2"
+  - match: "(.+)\\.task_instance_created-(.+)$"
+    match_metric_type: counter
+    name: "af_agg_operator_failures"
+    match_type: regex
+    labels:
+      airflow_id: "$1"
+      operator_name: "$2"
+  - match: "*.triggers.blocked_main_thread"
+    match_metric_type: counter
+    name: "af_agg_triggers_blocked_main_thread"
+    labels:
+      airflow_id: "$1"
+  - match: "*.triggers.failed"
+    match_metric_type: counter
+    name: "af_agg_triggers_failed"
+    labels:
+      airflow_id: "$1"
+  - match: "*.triggers.succeeded"
+    match_metric_type: counter
+    name: "af_agg_triggers_succeeded"
+    labels:
+      airflow_id: "$1"
 
   # === Gauges ===
   - match: "*.dagbag_size"
@@ -131,12 +182,6 @@ mappings:
     name: "af_agg_dag_processing_total_parse_time"
     labels:
       airflow_id: "$1"
-  - match: "*.dag_processing.last_runtime.*"
-    match_metric_type: gauge
-    name: "af_agg_dag_processing_last_runtime"
-    labels:
-      airflow_id: "$1"
-      dag_file: "$2"
   - match: "*.dag_processing.last_run.seconds_ago.*"
     match_metric_type: gauge
     name: "af_agg_dag_processing_last_run_seconds"
@@ -146,6 +191,21 @@ mappings:
   - match: "*.dag_processing.processor_timeouts"
     match_metric_type: gauge
     name: "af_agg_dag_processing_processor_timeouts"
+    labels:
+      airflow_id: "$1"
+  - match: "*.scheduler.tasks.running"
+    match_metric_type: gauge
+    name: "af_agg_scheduler_tasks_running"
+    labels:
+      airflow_id: "$1"
+  - match: "*.scheduler.tasks.starving"
+    match_metric_type: gauge
+    name: "af_agg_scheduler_tasks_starving"
+    labels:
+      airflow_id: "$1"
+  - match: "*.scheduler.tasks.executable"
+    match_metric_type: gauge
+    name: "af_agg_scheduler_tasks_executable"
     labels:
       airflow_id: "$1"
   - match: "*.executor.open_slots"
@@ -212,6 +272,11 @@ mappings:
     name: "af_agg_smart_sensor_operator_infra_failures"
     labels:
       airflow_id: "$1"
+  - match: "*.triggers.running"
+    match_metric_type: gauge
+    name: "af_agg_triggers_running"
+    labels:
+      airflow_id: "$1"
 
   # === Timers ===
   - match: "*.dagrun.dependency-check.*"
@@ -262,3 +327,8 @@ mappings:
     labels:
       airflow_id: "$1"
       dag_id: "$2"
+  - match: "*.collect_db_dags"
+    match_metric_type: observer
+    name: "af_agg_collect_db_dags"
+    labels:
+      airflow_id: "$1"

--- a/statsd/statsd.conf
+++ b/statsd/statsd.conf
@@ -145,7 +145,7 @@ mappings:
       dag_id: "$2"
   - match: "(.+)\\.task_instance_created-(.+)$"
     match_metric_type: counter
-    name: "af_agg_operator_failures"
+    name: "af_agg_task_instances_created"
     match_type: regex
     labels:
       airflow_id: "$1"


### PR DESCRIPTION
Added new metrics and removed metrics that don't exist anymore.
Furthermore moved some counters to become gauges (according to Airflow documentation).
Also added one more SLA metric that is not yet in the documentation but is in the code: sla_callback_notification_failure

I will updatet the dashboard later.