### PR TITLE
Fixing mapping config to support dags with periods in their names

### DIFF
--- a/statsd/statsd.conf
+++ b/statsd/statsd.conf
@@ -89,15 +89,17 @@ mappings:
     name: "af_agg_sla_email_notification_failure"
     labels:
       airflow_id: "$1"
-  - match: "*.ti.start.*.*"
+  - match: "([^.]+)\\.ti\\.start\\.(.+)\\.([^.]+)"
     match_metric_type: counter
+    match_type: regex
     name: "af_agg_ti_start"
     labels:
       airflow_id: "$1"
       dag_id: "$2"
       task_id: "$3"
-  - match: "*.ti.finish.*.*.*"
+  - match: "([^.]+)\\.ti\\.finish\\.(.+)\\.([^.]+)\\.([^.]+)"
     match_metric_type: counter
+    match_type: regex
     name: "af_agg_ti_finish"
     labels:
       airflow_id: "$1"
@@ -131,14 +133,16 @@ mappings:
     name: "af_agg_dag_processing_total_parse_time"
     labels:
       airflow_id: "$1"
-  - match: "*.dag_processing.last_runtime.*"
+  - match: "([^.]+)\\.dag_processing\\.last_runtime\\.(.+)"
     match_metric_type: gauge
+    match_type: regex
     name: "af_agg_dag_processing_last_runtime"
     labels:
       airflow_id: "$1"
       dag_file: "$2"
-  - match: "*.dag_processing.last_run.seconds_ago.*"
+  - match: "([^.]+)\\.dag_processing\\.last_run\\.seconds_ago\\.(.+)"
     match_metric_type: gauge
+    match_type: regex
     name: "af_agg_dag_processing_last_run_seconds"
     labels:
       airflow_id: "$1"
@@ -214,39 +218,45 @@ mappings:
       airflow_id: "$1"
 
   # === Timers ===
-  - match: "*.dagrun.dependency-check.*"
+  - match: "([^.]*)\\.dagrun\\.dependency-check\\.(.+)"
     match_metric_type: observer
+    match_type: regex
     name: "af_agg_dagrun_dependency_check"
     labels:
       airflow_id: "$1"
       dag_id: "$2"
-  - match: "*.dag.*.*.duration"
+  - match: "([^.]+)\\.dag\\.(.+)\\.([^.]+)\\.duration"
     match_metric_type: observer
+    match_type: regex
     name: "af_agg_dag_task_duration"
     labels:
       airflow_id: "$1"
       dag_id: "$2"
       task_id: "$3"
-  - match: "*.dag_processing.last_duration.*"
+  - match: "([^.]+)\\.dag_processing\\.last_duration\\.(.+)"
     match_metric_type: observer
+    match_type: regex
     name: "af_agg_dag_processing_duration"
     labels:
       airflow_id: "$1"
       dag_file: "$2"
-  - match: "*.dagrun.duration.success.*"
+  - match: "([^.]+)\\.dagrun\\.duration\\.success\\.(.+)"
     match_metric_type: observer
+    match_type: regex
     name: "af_agg_dagrun_duration_success"
     labels:
       airflow_id: "$1"
       dag_id: "$2"
-  - match: "*.dagrun.duration.failed.*"
+  - match: "([^.]+)\\.dagrun\\.duration\\.failed\\.(.+)"
     match_metric_type: observer
+    match_type: regex
     name: "af_agg_dagrun_duration_failed"
     labels:
       airflow_id: "$1"
       dag_id: "$2"
-  - match: "*.dagrun.schedule_delay.*"
+  - match: "([^.]+)\\.dagrun\\.schedule_delay\\.(.+)"
     match_metric_type: observer
+    match_type: regex
     name: "af_agg_dagrun_schedule_delay"
     labels:
       airflow_id: "$1"
@@ -256,8 +266,9 @@ mappings:
     name: "af_agg_scheduler_critical_section_duration"
     labels:
       airflow_id: "$1"
-  - match: "*.dagrun.*.first_task_scheduling_delay"
+  - match: "([^.]+)\\.dagrun\\.(.+)\\.first_task_scheduling_delay"
     match_metric_type: observer
+    match_type: regex
     name: "af_agg_dagrun_first_task_scheduling_delay"
     labels:
       airflow_id: "$1"


### PR DESCRIPTION
There is an issue with a bunch of these glob matchers when the dag names have a period in them.  The default `*` on the statsd glob matcher doesn't match `.`.  These changes update these mappings to use regexes to support potential periods in dag names.  My company has a ton of these already unfortunately.  This seems to be working for us at the moment, I just tested out these changes.